### PR TITLE
Update package dependencies to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-server</artifactId>
-            <version>3.141.59</version>
+            <version>4.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.3.1</version>
+            <version>6.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Update selenium-server from 3.141.59 to 4.7.1 (addresses vulnerability for versions <= 4.0.0-alpha-2)
- Update webdrivermanager from 5.3.1 to 6.1.0 (fixes CVE-2025-4641 Critical severity)