### PR TITLE
Fix CVE-2025-4641: Upgrade webdrivermanager to 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <selenium.version>4.27.0</selenium.version>
-        <webdrivermanager.version>5.9.2</webdrivermanager.version>
+        <webdrivermanager.version>6.1.0</webdrivermanager.version>
     </properties>
     <dependencies>
         <!-- Selenium Java - includes all necessary Selenium modules -->


### PR DESCRIPTION
Upgrade io.github.bonigarcia:webdrivermanager from 5.9.2 to 6.1.0 to address critical security vulnerability CVE-2025-4641 affecting versions >= 1.0.0 < 6.1.0.